### PR TITLE
Adds Shorthand + GH Actions for Publish and Build 

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -14,8 +14,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Tests
-      run: cargo test
+    - name: Release build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+    - name: Release build
+      uses: actions-rs/cargo@v1
+      with:
+        command: test

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3,7 +3,7 @@ name: Build and Test
 on:
   pull_request:
     types:
-      - opened
+      - edited
     paths:
       - 'src/**.rs'
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,9 +1,7 @@
 name: Build and Test
 
 on:
-  pull_request:
-    types:
-      - edited
+  push:
     paths:
       - 'src/**.rs'
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,0 +1,23 @@
+name: Build and Test
+
+on:
+  pull_request:
+    types:
+      - opened
+    paths:
+      - 'src/**.rs'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    if-merged:
+      if: github.event.pull_request.merged == true
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose
+      - name: Tests
+        run: cargo test

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,12 +12,10 @@ env:
 
 jobs:
   build:
-    if-merged:
-      if: github.event.pull_request.merged == true
-      runs-on: ubuntu-latest
-      steps:
-      - uses: actions/checkout@v3
-      - name: Build
-        run: cargo build --verbose
-      - name: Tests
-        run: cargo test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Tests
+      run: cargo test

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -17,8 +17,12 @@ jobs:
       if: github.event.pull_request.merged == true
       runs-on: ubuntu-latest
       steps:
-      - uses: actions/checkout@v3
       - name: Build
-        run: cargo build --verbose
-      - name: Run publish
-        run: cargo publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+        args: --release
+      - name: Publish to Cargo
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,24 @@
+name: Publish and Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches: [ "main" ]
+    paths:
+      - 'src/**.rs'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    if-merged:
+      if: github.event.pull_request.merged == true
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose
+      - name: Run publish
+        run: cargo publish

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -6,7 +6,7 @@ on:
       - closed
     branches: [ "main" ]
     paths:
-      - 'src/**.rs'
+      - 'version.yaml'
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [0.2.0] - 2023-04-07
+
+## Added
+- shorthand comannds to jump to and set portals.
+- adds ez-init command to configure shorthand for your shell.
 
 # [0.1.1] - 2023-02-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "prtl"
-version = "0.2.0"
+version = "0.2.0-alpha"
 dependencies = [
  "clap",
  "confy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "prtl"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "confy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +37,16 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bstr"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -120,6 +139,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,10 +237,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "directories"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
  "dirs-sys",
 ]
@@ -225,6 +278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +295,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +313,15 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -260,6 +339,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -282,6 +374,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -320,6 +418,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,13 +446,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.4"
+name = "instant"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -346,10 +471,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "io-lifetimes",
- "rustix",
- "windows-sys",
+ "rustix 0.36.7",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -368,10 +493,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.139"
+name = "lazy_static"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "link-cplusplus"
@@ -395,6 +526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +539,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "num-integer"
@@ -420,6 +563,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
 ]
 
 [[package]]
@@ -469,10 +622,12 @@ dependencies = [
 
 [[package]]
 name = "prtl"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "clap",
  "confy",
+ "dialoguer",
+ "rust_search",
  "serde",
  "serde_derive",
  "serde_with",
@@ -497,14 +652,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
+]
+
+[[package]]
+name = "regex"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "rust_search"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27d7be20245d289c9dde663f06521de08663d73cbaefc45785aa65d02022378"
+dependencies = [
+ "dirs",
+ "ignore",
+ "num_cpus",
+ "regex",
+ "strsim",
 ]
 
 [[package]]
@@ -514,11 +708,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aef160324be24d31a62147fae491c14d2204a3865c7ca8c3b0d7f7bcb3ea635"
+dependencies = [
+ "bitflags",
+ "errno 0.3.0",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -526,6 +734,15 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scratch"
@@ -605,6 +822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +842,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix 0.37.8",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -648,6 +884,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -694,6 +940,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -792,13 +1048,61 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -808,10 +1112,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -820,10 +1136,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -832,16 +1160,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "yaml-rust"
@@ -851,3 +1197,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prtl"
-version = "0.1.2"
+version = "0.2.0"
 license = "MIT"
 description = "Jump to tagged directories quickly with prtl."
 edition = "2021"
@@ -13,3 +13,5 @@ confy = { version = "0.5.1", features = ["yaml_conf"], default-features=false }
 serde = "1.0.152"
 serde_derive = "1.0.152"
 serde_with = "2.2.0"
+rust_search = "2.0.0"
+dialoguer = "0.10.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prtl"
-version = "0.2.0"
+version = "0.2.0-alpha"
 license = "MIT"
 description = "Jump to tagged directories quickly with prtl."
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prtl"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 description = "Jump to tagged directories quickly with prtl."
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@ Small tool to keep track of your tagged directories. Portal to tagged locations 
 - ```git clone https://github.com/ShounakA/prtl.git```
 - ```cd prtl && cargo build --release```
 
+## Manually Configure Shorthand
+
+### Bash
+1. Add a new shell file `path/to/your/newly/created/script/file.sh` with: 
+   ```bash
+   function p() {
+      if [[ $1 = "get" ]]; then 
+         cd $(prtl "$@")
+      elif [[ $1 = "set" ]]; then
+         $(prtl $@)
+      else
+         echo Global options will not work. Type \'prtl -h\' for more info.
+         echo \'p\' short-hand only supports \'get\' and \'set\' commands. 
+      fi
+   }
+   ```
+2. Update your .bashrc | .bash_profile | .profile to include:
+``` source path/to/your/newly/created/script/file.sh ```
+
 ## Usage
 
 - ```prtl -h``` -> Help command
@@ -19,7 +38,12 @@ Small tool to keep track of your tagged directories. Portal to tagged locations 
 - ```cd $(prtl get)``` -> Take the prtl to your default directory
 - ```cd $(prtl get <tag>)``` -> Take the prtl to a tagged prtl
 
+__With shorthand configured__ 
+ - ```p get``` is short for ```cd $(prtl get)```
+ - ```p get <tag>``` is short for ```cd $(prtl get <tag>)```
+ - ```p set <path>``` is short for ```prtl set <path>```
+ - ```p set <path> -t <tag>``` is short for ```prtl set <path> -t <tag>```
 
 ## Contribute
 Hello, if you stumble upon this repo and think it is worthy of your time you may contribute in the future.
-Currently, I don't have and PR templates, tests, or guides setup. But I may add them soon, stay tuned!  
+Currently, I don't have any PR templates, tests, or guides setup. But I may add them soon, stay tuned!  

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,6 +2,8 @@ use clap::{Parser, arg, Subcommand};
 
 pub const DEFAULT_PRTL_TAG: &str = "default_prtl";
 pub const CONFIG_APP_NAME: &str = ".prtl";
+pub const SHELL_TAG_BASH: &str = "bash";
+
 
 /// prtl arguments
 /// Usage: prtl <COMMAND>
@@ -37,5 +39,11 @@ pub enum Commands {
         /// A tag representing a directory
         #[arg(default_value = DEFAULT_PRTL_TAG)]
         tag: String
-    }
+    },
+
+    EzInit {
+        /// A shell id to configure shorthand script
+        #[arg(default_value = SHELL_TAG_BASH)]
+        shell: String
+    },
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,41 @@
+use clap::{Parser, arg, Subcommand};
+
+pub const DEFAULT_PRTL_TAG: &str = "default_prtl";
+pub const CONFIG_APP_NAME: &str = ".prtl";
+
+/// prtl arguments
+/// Usage: prtl <COMMAND>
+///
+/// Commands:
+///   set   
+///   get   
+///   help  Print this message or the help of the given subcommand(s)
+///
+/// Options:
+///   -h, --help     Print help
+///   -V, --version  Print version
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct PortalArgs {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+
+    Set {
+        /// path to set as last directory.
+        path: String,
+        
+        /// give the directory a tag.
+        #[arg(short, default_value = DEFAULT_PRTL_TAG)]
+        tag: String,
+    },
+    
+    Get {
+        /// A tag representing a directory
+        #[arg(default_value = DEFAULT_PRTL_TAG)]
+        tag: String
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,54 +1,15 @@
+mod args;
+
 use core::fmt;
 use std::collections::HashMap;
-use std::error::Error;
 use std::{fs, io};
 use std::path::PathBuf;
 use std::io::Write as IoWrite;
-
-use clap::{Parser, arg, Subcommand};
+use clap::Parser;
 use serde_derive::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-
-const DEFAULT_PRTL_TAG: &str = "default_prtl";
-const CONFIG_APP_NAME: &str = ".prtl";
-
-/// prtl arguments
-/// Usage: prtl <COMMAND>
-///
-/// Commands:
-///   set   
-///   get   
-///   help  Print this message or the help of the given subcommand(s)
-///
-/// Options:
-///   -h, --help     Print help
-///   -V, --version  Print version
-#[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
-struct PortalArgs {
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Subcommand, Debug)]
-enum Commands {
-
-    Set {
-        /// path to set as last directory.
-        path: String,
-        
-        /// give the directory a tag.
-        #[arg(short, default_value= DEFAULT_PRTL_TAG)]
-        tag: String,
-    },
-    
-    Get {
-        /// A tag representing a directory
-        #[arg(default_value= DEFAULT_PRTL_TAG)]
-        tag: String
-    }
-}
+use args::{Commands, DEFAULT_PRTL_TAG, CONFIG_APP_NAME, PortalArgs};
 
 /// prtl config stores the default_prtl tag as well as all the custom tags
 #[serde_as]
@@ -64,8 +25,6 @@ struct PortalConfig {
 struct PortalError {
    message: String,
 }
-
-impl Error for PortalError {}
 
 impl fmt::Display for PortalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -107,8 +66,8 @@ fn main() -> Result<(), PortalError> {
          cfg.portal_map.insert((&tag).to_string(), canonical_dir);
       },
       Commands::Get { tag } => {
-         if let Some(value) = &cfg.portal_map.get(tag) {
-           writeln!(&mut stdout, "{}", value).ok();
+         if let Some(value) = cfg.portal_map.get(tag) {
+            writeln!(&mut stdout, "{}", value).ok();
          } 
          else {
             return Err(PortalError { message: format!("Did not find prtl with tag {}", tag)});

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,24 @@
 mod args;
+mod tpl;
 
 use core::fmt;
 use std::collections::HashMap;
-use std::{fs, io};
+use std::io::Error;
+use std::fs::{OpenOptions, File};
+use std::{fs};
 use std::path::PathBuf;
 use std::io::Write as IoWrite;
 use clap::Parser;
+use dialoguer::{Select, Input};
+use dialoguer::console::Term;
+use dialoguer::theme::ColorfulTheme;
+use rust_search::SearchBuilder;
 use serde_derive::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use args::{Commands, DEFAULT_PRTL_TAG, CONFIG_APP_NAME, PortalArgs};
+use args::{Commands, DEFAULT_PRTL_TAG, CONFIG_APP_NAME, SHELL_TAG_BASH, PortalArgs};
+
+use crate::tpl::PRTL_SHORTHAND_SCRIPT;
 
 /// prtl config stores the default_prtl tag as well as all the custom tags
 #[serde_as]
@@ -47,20 +56,20 @@ impl ::std::default::Default for PortalConfig {
 ///   -h, --help     Print help
 ///   -V, --version  Print version
 fn main() -> Result<(), PortalError> {
-   // Load config file
+
    let mut cfg: PortalConfig = match confy::load(CONFIG_APP_NAME, None) {
       Ok(config) => config,
       Err(_e) => return Err(PortalError { message: format!("Error loading config.") })
    };
    
    let args = PortalArgs::parse();
-   let mut stdout = io::stdout();
+   let mut stdout = &Term::stdout();
 
    match &args.command {
       Commands::Set { path, tag } => {
          let srcdir = PathBuf::from(path);
          let canonical_dir = match fs::canonicalize(srcdir) {
-            Ok(path) => path.to_string_lossy().into_owned(),
+            Ok(path) => path.to_string_lossy().to_string(),
             Err(_e) => return Err(PortalError { message: format!("Path {} is invalid.", &path) } ),
          };
          cfg.portal_map.insert((&tag).to_string(), canonical_dir);
@@ -72,6 +81,16 @@ fn main() -> Result<(), PortalError> {
          else {
             return Err(PortalError { message: format!("Did not find prtl with tag {}", tag)});
          }
+      },
+      Commands::EzInit { shell } => {
+         match shell.as_str() {
+            SHELL_TAG_BASH => {
+               return setup_bash();
+            }, 
+            _ => {
+               writeln!(stdout, "Usupported shell. Please try and configure manually.").expect("Could not write to terminal. ¯\\_(ツ)_/¯");
+            },
+         }
       }
    };
 
@@ -79,4 +98,84 @@ fn main() -> Result<(), PortalError> {
       Ok(()) => Ok({}),
       Err(_e) => Err(PortalError { message: "Failed to save config".to_string()} ),
    }
+}
+
+fn setup_bash() -> Result<(), PortalError> {
+   // Search for Bash Profile
+   let search_input = ".bash";
+   let mut search: Vec<String> = SearchBuilder::default()
+       .location("~/")
+       .search_input(search_input)
+       .ignore_case()
+       .depth(3)
+       .limit(20)
+       .hidden()
+       .build()
+      .collect();
+
+   //Add custom option if the file was not found in search.
+   let default: String = "Custom".to_string();
+   search.push(default);
+
+   // Show selections in terminal
+   let selection = Select::with_theme(&ColorfulTheme::default())
+   .items(&search)
+   .default(0)
+   .interact_on_opt(&Term::stderr()).expect("Should've selected 'Custom' ¯\\_(ツ)_/¯");
+
+   let selected_option = match selection {
+      Some(index) => &search[index],
+      None => &search[0],
+   };
+   
+   // write the script file here
+   let file_to_write = match selected_option.as_str() {
+      "Custom" => {
+         let custom_file = match Input::<String>::new()
+            .with_prompt("Enter the file path to your bash profile")
+            .interact_text(){
+                Ok(typed_text) => typed_text,
+                Err(_) => return Err(PortalError { message: format!("¯\\_(ツ)_/¯ Something went wrong with input")} ),
+            };
+         let canonical_dir = match fs::canonicalize(&custom_file) {
+            Ok(path) => path.to_string_lossy().to_string(),
+            Err(_e) => return Err(PortalError { message: format!("Path {} is invalid.", custom_file) } ),
+         };
+         canonical_dir
+      },
+      _ => {selected_option.to_string()}
+   };
+
+   //
+   let mut path = PathBuf::from(&file_to_write);
+   path.pop();
+   path.push("prtl_shorthand.sh");
+
+   let shorthand_path = path.to_string_lossy().to_string();
+   match write_shorthand_file(&shorthand_path) {
+      Ok(_) => (),
+      Err(_e) => return Err(PortalError{ message: format!("")})
+   };
+   return match write_to_profile(&file_to_write, shorthand_path){
+      Ok(_) => Ok(()),
+      Err(_e) => Err(PortalError { message: format!("Failed to write to file. Try manual configuration: https://github.com/ShounakA/prtl#readme") })
+   };
+}
+
+fn write_to_profile(selected_option: &String, shorthand_path: String) -> Result<(), Error> {
+   let mut file = OpenOptions::new()
+      .write(true)
+      .append(true)
+      .open(selected_option)
+      .unwrap();
+
+   match writeln!(file, "source {}", shorthand_path) {
+      Ok(_) => Ok(()),
+      Err(e) => Err(e)
+   }
+}
+
+fn write_shorthand_file(shorthand_path: &String) -> Result<(), Error> {
+   let mut file = File::create(shorthand_path)?;
+   write!(file, "{}", PRTL_SHORTHAND_SCRIPT)
 }

--- a/src/mod.rs
+++ b/src/mod.rs
@@ -1,0 +1,1 @@
+mod args;

--- a/src/mod.rs
+++ b/src/mod.rs
@@ -1,1 +1,2 @@
 mod args;
+mod tpl;

--- a/src/tpl.rs
+++ b/src/tpl.rs
@@ -1,0 +1,13 @@
+
+pub const PRTL_SHORTHAND_SCRIPT: &str = r#"
+function p() {
+   if [[ $1 = "get" ]]; then 
+     cd $(prtl "$@")
+   elif [[ $1 = "set" ]]; then
+     $(prtl $@)
+   else
+     echo Global options will not work. Type \'prtl -h\' for more info.
+     echo \'p\' short-hand only supports \'get\' and \'set\' commands. 
+   fi
+}
+"#;

--- a/version.yaml
+++ b/version.yaml
@@ -1,0 +1,4 @@
+major: 0
+minor: 2
+patch: 0
+name: alpha


### PR DESCRIPTION
Adds shorthand command for getting and setting portals:
 - ```p get``` is short for ```cd $(prtl get)```
 - ```p get <tag>``` is short for ```cd $(prtl get <tag>)```
 - ```p set <path>``` is short for ```prtl set <path>```
 - ```p set <path> -t <tag>``` is short for ```prtl set <path> -t <tag>```
Adds auto-configuration for bash shell:
- ```prtl ez-init``` to auto add shorthand configs to your shell.